### PR TITLE
fix: reorder information to make notifications more useful

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,6 @@
     # The #adr-notifications channel in the Open edX Slack.
     # "s5c2n2m2v2t0b2l2@openedx.slack.com" is on the ggroup.
     - "adr-notifications@googlegroups.com"
-  subject: "Change in {{repo}}: {{pr.title}}"
+  subject: "{{pr.title}}, in {{repo}}"
   body: adr-body.txt
 "openedx/*": *adr_config

--- a/templates/adr-body.txt
+++ b/templates/adr-body.txt
@@ -1,6 +1,6 @@
-A pull request has files you might be interested in.
+{{ pr.user.login }} {{ action }} this pull request:
 
-"{{ pr.title }}" ({{ pr_url }} by {{ pr.user.login }}) against the {{ repo }} repository (branch {{ pr.base.ref }}) has been {{ action }}.
+"{{ pr.title }}" ({{ pr_url }}) against the {{ repo }} repository (branch {{ pr.base.ref }}).
 
 Changed files matching the filter:
 {% for modified_file in modified_files %}


### PR DESCRIPTION
Put high-information words first so when notifications cut off text,
they are still useful.